### PR TITLE
Specify InvalidContextException is code 36

### DIFF
--- a/spec-draft.md
+++ b/spec-draft.md
@@ -309,7 +309,7 @@ return to the original context.
 If a server receives a request at an endpoint which is valid in some context
 but not the currently active context (for example if a user calls
 `driver.get()` in a native context instead of a webview context), the server
-must respond with an InvalidContentException.
+must respond with an InvalidContextException (code 36).
 
 Waiting for Conditions
 ----------------------


### PR DESCRIPTION
Currently `InvalidContextException` has no code associated with it. Specify that it is `36`, the next number in sequence (and what is [currently being used by Appium](https://github.com/appium/node-mobile-json-wire-protocol/blob/master/lib/errors.js#L267)).

Also fix name from `InvalidContentException` to `InvalidContextException`
